### PR TITLE
Center logo on mobile screens and left-align on desktop

### DIFF
--- a/snippets/header.liquid
+++ b/snippets/header.liquid
@@ -33,7 +33,7 @@
             {% render 'mobile-menu' %}
         </nav>
 
-        <a href="{{ routes.root_url }}" class="text-white no-underline text-2xl md:text-3xl uppercase ml-4 md:ml-0">
+        <a href="{{ routes.root_url }}" class="text-white no-underline text-2xl md:text-3xl uppercase mx-auto md:mx-0">
             {% if settings.logo %}
                 {{ settings.logo | image_url: width: 200 | image_tag:
                     loading: "lazy",


### PR DESCRIPTION
Changed logo alignment classes from `ml-4 md:ml-0` to `mx-auto md:mx-0` to center the logo horizontally on mobile screens (below 768px breakpoint) while keeping it left-aligned on larger screens.